### PR TITLE
Title: Save and Restore Instance State for RatingBar

### DIFF
--- a/library/src/main/java/com/willy/ratingbar/BaseRatingBar.java
+++ b/library/src/main/java/com/willy/ratingbar/BaseRatingBar.java
@@ -3,6 +3,8 @@ package com.willy.ratingbar;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.FloatRange;
 import android.support.annotation.Nullable;
@@ -12,6 +14,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -385,5 +388,60 @@ public class BaseRatingBar extends LinearLayout implements SimpleRatingBar {
 
     public void setStepSize(@FloatRange(from = 0.1, to = 1.0) float stepSize) {
         this.mStepSize = stepSize;
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        Parcelable superState = super.onSaveInstanceState();
+        SavedState ss = new SavedState(superState);
+
+        ss.rating = mRating;
+        return ss;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        super.onRestoreInstanceState(state);
+
+        SavedState ss = (SavedState) state;
+        super.onRestoreInstanceState(ss.getSuperState());
+
+        setRating(ss.rating);
+    }
+
+    static class SavedState extends BaseSavedState {
+        float rating;
+
+        /**
+         * Constructor called from {@link BaseRatingBar#onSaveInstanceState()}
+         */
+        SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        /**
+         * Constructor called from {@link #CREATOR}
+         */
+        private SavedState(Parcel in) {
+            super(in);
+            rating = in.readFloat();
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeFloat(rating);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR
+                = new Parcelable.Creator<SavedState>() {
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
+
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
     }
 }


### PR DESCRIPTION
Cause: When fragment/activity is recreated, the rating state is lost
Countermeasure: Added a Saved State parcelable class and added rating as a field for saving view state