### PR TITLE
Set rating should respect step size

### DIFF
--- a/library/src/main/java/com/willy/ratingbar/BaseRatingBar.java
+++ b/library/src/main/java/com/willy/ratingbar/BaseRatingBar.java
@@ -206,7 +206,11 @@ public class BaseRatingBar extends LinearLayout implements SimpleRatingBar {
             return;
         }
 
-        mRating = rating;
+        // Respect Step size. So if the defined step size is 0.5, and we're attributing it a 4.7 rating,
+        // it should actually be set to `4.5` rating.
+        float stepAbidingRating = Double.valueOf(Math.floor(rating/mStepSize)).floatValue() * mStepSize;
+
+        mRating = stepAbidingRating;
 
         if (mOnRatingChangeListener != null) {
             mOnRatingChangeListener.onRatingChange(this, mRating, fromUser);


### PR DESCRIPTION
The changed code is pretty self-explanatory. In my case I have a step of 1 in my app, and setting the value from the backend that was decimal was resulting in unexpected floating precision on the rating bar. This behavior is now consistent with how step and setRating work for Android's native RatingBar.